### PR TITLE
allowedDeviationXY - Reworked

### DIFF
--- a/LIF.md
+++ b/LIF.md
@@ -462,7 +462,7 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 - If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, aMinimum <= aMaximum / bMinimum <= bMaximum is assumed.
 - If neither aMinimum/aMaximum nor bMinimum/bMaximum are defined at all, the fleet control may send any value when compiling an order.
 
-In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMin = aMax, bMin = bMax, and theta = 0.0 in order to define a circle.
+In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMinimum = aMaximum, bMinimum = bMaximum, and theta = 0.0 in order to define a circle.
 
 | Object structure | Unit | Data type | Description |
 | --- | --- | --- | --- |

--- a/LIF.md
+++ b/LIF.md
@@ -464,7 +464,6 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMinimum = aMaximum, bMinimum = bMaximum, and theta = 0.0 in order to define a circle.
 
-Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
 
 Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
 

--- a/LIF.md
+++ b/LIF.md
@@ -473,7 +473,7 @@ Regardless of the values defined for the ellipse, due to the fact that the fleet
 | *aMaximum* | meter | float64 | Maximum length of the ellipse semi-major axis in meters. |
 | *bMinimum* | meter | float64 | Minimum length of the ellipse semi-minor axis in meters. |
 | *bMaximum* | meter | float64 | Maximum length of the ellipse semi-minor axis in meters. |
-| *theta* | rad | float64 | Rotation angle from the positive horizontal axis to the ellipse's major axis in the project-specific coordinate system. |
+| *theta* | rad | float64 | Rotation angle from the positive horizontal axis to the ellipse's major axis in this origin's coordinate system. |
 | } |  |  |  |
 
 ### 8.3.18 Corridor

--- a/LIF.md
+++ b/LIF.md
@@ -467,7 +467,7 @@ In the case that an ellipse is not supported by either the mobile robot or by VD
 | Object structure | Unit | Data type | Description |
 | --- | --- | --- | --- |
 | allowedDeviationXY { |  | JSON-object |  |
-| *aMin* | meter | float64 | Minimum length of the ellipse semi-major axis in meters. |
+| *aMinimum* | meter | float64 | Minimum length of the ellipse semi-major axis in meters. |
 | *aMax* | meter | float64 | Maximum length of the ellipse semi-major axis in meters. |
 | *bMin* | meter | float64 | Minimum length of the ellipse semi-minor axis in meters. |
 | *bMax* | meter | float64 | Maximum length of the ellipse semi-minor axis in meters. |

--- a/LIF.md
+++ b/LIF.md
@@ -455,20 +455,24 @@ If the (third-party) fleet control system would need to graphically identify cer
 
 ### 8.3.17 AllowedDeviationXY
 
-Indicates how precisely a mobile robot shall match the position of a node for it to be considered traversed.
+allowedDeviationXY defines an ellipse around the node position within which the mobile robot's control point may deviate from the exact node coordinates. The coordinates of the node define the center of the ellipse. 
 
-If a = b = 0.0: no deviation is allowed, which means the mobile robot shall reach or pass the node position with the mobile robot control point as precisely as is technically possible for the mobile robot. This applies also if allowedDeviationXY is smaller than what is technically viable for the mobile robot. If the mobile robot supports this attribute, but it is not defined for this node by the fleet control system the mobile robot shall assume the value of a and b as 0.0.
+- If aMin = aMax and bMin = bMax, the provided allowedDeviationXY must be sent for this node with every order.
+- If aMin/bMin is defined but aMax/bMax is not, aMax >= aMin / bMax >= bMin is assumed.
+- If aMax/bMax is defined but aMin/bMin is not, aMin <= aMax / bMin <= bMax is assumed.
+- If neither aMin/aMax nor bMin/bMax is defined at all, the fleet control may send any value when compiling an order.
 
-In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), it should be defined such that a = b and theta = 0.0 in order to define a circle.
+In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMin = aMax, bMin = bMax, and theta = 0.0 in order to define a circle.
 
 | Object structure | Unit | Data type | Description |
 | --- | --- | --- | --- |
 | allowedDeviationXY { |  | JSON-object |  |
-| a | meter | float64 | length of the ellipse semi-major axis in meters. |
-| b | meter | float64 | length of the ellipse semi-minor axis in meters. |
-| theta |  | float64 | rotation angle (the angle from the positive horizontal axis to the ellipse's major axis inside the project-specific coordinate system). |
+| *aMin* | meter | float64 | Minimum length of the ellipse semi-major axis in meters. |
+| *aMax* | meter | float64 | Maximum length of the ellipse semi-major axis in meters. |
+| *bMin* | meter | float64 | Minimum length of the ellipse semi-minor axis in meters. |
+| *bMax* | meter | float64 | Maximum length of the ellipse semi-minor axis in meters. |
+| *theta* | rad | float64 | Rotation angle from the positive horizontal axis to the ellipse's major axis in the project-specific coordinate system. |
 | } |  |  |  |
-*The coordinates of the node defines the center of the ellipse.*
 
 ### 8.3.16 Corridor
 
@@ -522,8 +526,10 @@ The complete data structure of LIF is shown below:
                            ],
                            "theta":"number",
                            "allowedDeviationXY":{
-                              "a":"number",
-                              "b":"number",
+                              "aMin":"number",
+                              "aMax":"number",
+                              "bMin":"number",
+                              "bMax":"number",
                               "theta":"number"
                            },
                            "loadRestriction":{

--- a/LIF.md
+++ b/LIF.md
@@ -459,7 +459,7 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 
 - If aMinimum = aMaximum and bMinimum = bMaximum, the provided allowedDeviationXY must be sent for this node with every order.
 - If aMinimum/bMinimum are defined but aMaximum/bMaximum are not, any value of the maximum equal to or greater than the corresponding minimum is assumed to be valid.
-- If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, aMinimum <= aMaximum / bMinimum <= bMaximum is assumed.
+- If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, any value of the minimum equal to or less than the corresponding maximum is assumed to be valid.
 - If neither aMinimum/aMaximum nor bMinimum/bMaximum are defined at all, the fleet control may send any value when compiling an order.
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMinimum = aMaximum, bMinimum = bMaximum, and theta = 0.0 in order to define a circle.

--- a/LIF.md
+++ b/LIF.md
@@ -458,7 +458,7 @@ If the (third-party) fleet control system would need to graphically identify cer
 allowedDeviationXY defines an ellipse around the node position within which the mobile robot's control point may deviate from the exact node coordinates while still considering the node traversed. The coordinates of the node define the center of the ellipse. 
 
 - If aMinimum = aMaximum and bMinimum = bMaximum, the provided allowedDeviationXY must be sent for this node with every order.
-- If aMinimum/bMinimum are defined but aMaximum/bMaximum are not, aMaximum >= aMinimum / bMaximum >= bMinimum is assumed.
+- If aMinimum/bMinimum are defined but aMaximum/bMaximum are not, any value of the maximum equal to or greater than the corresponding minimum is assumed to be valid.
 - If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, aMinimum <= aMaximum / bMinimum <= bMaximum is assumed.
 - If neither aMinimum/aMaximum nor bMinimum/bMaximum are defined at all, the fleet control may send any value when compiling an order.
 

--- a/LIF.md
+++ b/LIF.md
@@ -455,7 +455,7 @@ If the (third-party) fleet control system would need to graphically identify cer
 
 ### 8.3.17 AllowedDeviationXY
 
-allowedDeviationXY defines an ellipse around the node position within which the mobile robot's control point may deviate from the exact node coordinates. The coordinates of the node define the center of the ellipse. 
+allowedDeviationXY defines an ellipse around the node position within which the mobile robot's control point may deviate from the exact node coordinates while still considering the node traversed. The coordinates of the node define the center of the ellipse. 
 
 - If aMin = aMax and bMin = bMax, the provided allowedDeviationXY must be sent for this node with every order.
 - If aMin/bMin are defined but aMax/bMax are not, aMax >= aMin / bMax >= bMin is assumed.

--- a/LIF.md
+++ b/LIF.md
@@ -464,6 +464,8 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMinimum = aMaximum, bMinimum = bMaximum, and theta = 0.0 in order to define a circle.
 
+Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
+
 | Object structure | Unit | Data type | Description |
 | --- | --- | --- | --- |
 | allowedDeviationXY { |  | JSON-object |  |

--- a/LIF.md
+++ b/LIF.md
@@ -466,6 +466,8 @@ In the case that an ellipse is not supported by either the mobile robot or by VD
 
 Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
 
+Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
+
 | Object structure | Unit | Data type | Description |
 | --- | --- | --- | --- |
 | allowedDeviationXY { |  | JSON-object |  |

--- a/LIF.md
+++ b/LIF.md
@@ -464,7 +464,6 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMinimum = aMaximum, bMinimum = bMaximum, and theta = 0.0 in order to define a circle.
 
-
 Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
 
 | Object structure | Unit | Data type | Description |

--- a/LIF.md
+++ b/LIF.md
@@ -462,7 +462,7 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 - If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, any value of the minimum equal to or less than the corresponding maximum is assumed to be valid.
 - If neither aMinimum/aMaximum nor bMinimum/bMaximum are defined at all, the fleet control may send any value when compiling an order.
 
-In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMinimum = aMaximum, bMinimum = bMaximum, and theta = 0.0 in order to define a circle.
+In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), the fleet control system must choose a single radius within the minimum and maximum bounds of both a and b when dispatching an order.
 
 Regardless of the values defined for the ellipse, due to the fact that the fleet control system must always ensure that any VDA5050 commands resulting from this information require that the semi-minor axis is equal to or less than the semi-major axis, values in the LIF that would directly force such an error are invalid.
 

--- a/LIF.md
+++ b/LIF.md
@@ -460,7 +460,7 @@ allowedDeviationXY defines an ellipse around the node position within which the 
 - If aMinimum = aMaximum and bMinimum = bMaximum, the provided allowedDeviationXY must be sent for this node with every order.
 - If aMinimum/bMinimum are defined but aMaximum/bMaximum are not, any value of the maximum equal to or greater than the corresponding minimum is assumed to be valid.
 - If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, any value of the minimum equal to or less than the corresponding maximum is assumed to be valid.
-- If neither aMinimum/aMaximum nor bMinimum/bMaximum are defined at all, the fleet control may send any value when compiling an order.
+- If neither pair of aMinimum/aMaximum or bMinimum/bMaximum are defined, the fleet control may send any value when compiling an order.
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), the fleet control system must choose a single radius within the minimum and maximum bounds of both a and b when dispatching an order.
 

--- a/LIF.md
+++ b/LIF.md
@@ -457,10 +457,10 @@ If the (third-party) fleet control system would need to graphically identify cer
 
 allowedDeviationXY defines an ellipse around the node position within which the mobile robot's control point may deviate from the exact node coordinates while still considering the node traversed. The coordinates of the node define the center of the ellipse. 
 
-- If aMin = aMax and bMin = bMax, the provided allowedDeviationXY must be sent for this node with every order.
-- If aMin/bMin are defined but aMax/bMax are not, aMax >= aMin / bMax >= bMin is assumed.
-- If aMax/bMax are defined but aMin/bMin are not, aMin <= aMax / bMin <= bMax is assumed.
-- If neither aMin/aMax nor bMin/bMax are defined at all, the fleet control may send any value when compiling an order.
+- If aMinimum = aMaximum and bMinimum = bMaximum, the provided allowedDeviationXY must be sent for this node with every order.
+- If aMinimum/bMinimum are defined but aMaximum/bMaximum are not, aMaximum >= aMinimum / bMaximum >= bMinimum is assumed.
+- If aMaximum/bMaximum are defined but aMinimum/bMinimum are not, aMinimum <= aMaximum / bMinimum <= bMaximum is assumed.
+- If neither aMinimum/aMaximum nor bMinimum/bMaximum are defined at all, the fleet control may send any value when compiling an order.
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMin = aMax, bMin = bMax, and theta = 0.0 in order to define a circle.
 
@@ -468,9 +468,9 @@ In the case that an ellipse is not supported by either the mobile robot or by VD
 | --- | --- | --- | --- |
 | allowedDeviationXY { |  | JSON-object |  |
 | *aMinimum* | meter | float64 | Minimum length of the ellipse semi-major axis in meters. |
-| *aMax* | meter | float64 | Maximum length of the ellipse semi-major axis in meters. |
-| *bMin* | meter | float64 | Minimum length of the ellipse semi-minor axis in meters. |
-| *bMax* | meter | float64 | Maximum length of the ellipse semi-minor axis in meters. |
+| *aMaximum* | meter | float64 | Maximum length of the ellipse semi-major axis in meters. |
+| *bMinimum* | meter | float64 | Minimum length of the ellipse semi-minor axis in meters. |
+| *bMaximum* | meter | float64 | Maximum length of the ellipse semi-minor axis in meters. |
 | *theta* | rad | float64 | Rotation angle from the positive horizontal axis to the ellipse's major axis in the project-specific coordinate system. |
 | } |  |  |  |
 
@@ -526,10 +526,10 @@ The complete data structure of LIF is shown below:
                            ],
                            "theta":"number",
                            "allowedDeviationXY":{
-                              "aMin":"number",
-                              "aMax":"number",
-                              "bMin":"number",
-                              "bMax":"number",
+                              "aMinimum":"number",
+                              "aMaximum":"number",
+                              "bMinimum":"number",
+                              "bMaximum":"number",
                               "theta":"number"
                            },
                            "loadRestriction":{

--- a/LIF.md
+++ b/LIF.md
@@ -458,9 +458,9 @@ If the (third-party) fleet control system would need to graphically identify cer
 allowedDeviationXY defines an ellipse around the node position within which the mobile robot's control point may deviate from the exact node coordinates. The coordinates of the node define the center of the ellipse. 
 
 - If aMin = aMax and bMin = bMax, the provided allowedDeviationXY must be sent for this node with every order.
-- If aMin/bMin is defined but aMax/bMax is not, aMax >= aMin / bMax >= bMin is assumed.
-- If aMax/bMax is defined but aMin/bMin is not, aMin <= aMax / bMin <= bMax is assumed.
-- If neither aMin/aMax nor bMin/bMax is defined at all, the fleet control may send any value when compiling an order.
+- If aMin/bMin are defined but aMax/bMax are not, aMax >= aMin / bMax >= bMin is assumed.
+- If aMax/bMax are defined but aMin/bMin are not, aMin <= aMax / bMin <= bMax is assumed.
+- If neither aMin/aMax nor bMin/bMax are defined at all, the fleet control may send any value when compiling an order.
 
 In the case that an ellipse is not supported by either the mobile robot or by VDA5050 version (e.g., 2.1 or prior), allowedDeviationXY should be defined such that aMin = aMax, bMin = bMax, and theta = 0.0 in order to define a circle.
 
@@ -474,7 +474,7 @@ In the case that an ellipse is not supported by either the mobile robot or by VD
 | *theta* | rad | float64 | Rotation angle from the positive horizontal axis to the ellipse's major axis in the project-specific coordinate system. |
 | } |  |  |  |
 
-### 8.3.16 Corridor
+### 8.3.18 Corridor
 
 | Object structure | Unit | Data type | Description |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Reworked allowedDeviationXY so deviation is now defined as a band between a min and a max ellipse, instead of one fixed ellipse, using new aMin/aMax/bMin/bMax fields instead of the single a/b values. 
