### PR TITLE
Small Fix: Align timestamp in new example files

### DIFF
--- a/examples/01-forward-edge.md
+++ b/examples/01-forward-edge.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_01",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/02-bidirectional-edge.md
+++ b/examples/02-bidirectional-edge.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_02",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/03-counter-clockwise-rotation-on-node.md
+++ b/examples/03-counter-clockwise-rotation-on-node.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_03",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/04-omnidirectional-edge.md
+++ b/examples/04-omnidirectional-edge.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_04",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/05-multiple-layouts-in-one-lif.md
+++ b/examples/05-multiple-layouts-in-one-lif.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_05",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/06-station-with-one-node.md
+++ b/examples/06-station-with-one-node.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_06",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/07-station-with-two-nodes.md
+++ b/examples/07-station-with-two-nodes.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_07",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/08-station-with-two-nodes-restricted.md
+++ b/examples/08-station-with-two-nodes-restricted.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_08",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/09-rotation-station.md
+++ b/examples/09-rotation-station.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_09",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/10-station-with-three-nodes-restricted.md
+++ b/examples/10-station-with-three-nodes-restricted.md
@@ -22,7 +22,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_10",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/11-multiple-edges-with-load-restrictions.md
+++ b/examples/11-multiple-edges-with-load-restrictions.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_11",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/12-multiple-edges-between-same-two-nodes.md
+++ b/examples/12-multiple-edges-between-same-two-nodes.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_12",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/13-battery-charging-station.md
+++ b/examples/13-battery-charging-station.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_13",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/14-two-levels-of-a-facility-in-one-lif-file.md
+++ b/examples/14-two-levels-of-a-facility-in-one-lif-file.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_14",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/15-rack-station-modelled-by-three-stations.md
+++ b/examples/15-rack-station-modelled-by-three-stations.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_15",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/16-rack-station-modelled-by-three-nodes.md
+++ b/examples/16-rack-station-modelled-by-three-nodes.md
@@ -12,7 +12,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_16",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/17-edge-with-trajectory-definition.md
+++ b/examples/17-edge-with-trajectory-definition.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_17",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/18-manufacturer-specific-action-on-an-edge.md
+++ b/examples/18-manufacturer-specific-action-on-an-edge.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_18",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [

--- a/examples/19-forward-edge-with-two-mobile-robot-types.md
+++ b/examples/19-forward-edge-with-two-mobile-robot-types.md
@@ -8,7 +8,7 @@ LIF-File:
     "metaInformation": {
         "lifId": "LIF_Example_19",
         "creator": "VDMA",
-        "exportTimestamp": "2026-09-28T10:00:00.00Z",
+        "exportTimestamp": "2026-09-28T10:00:00.000Z",
         "lifVersion": "2.0.0"
     },
     "origins": [


### PR DESCRIPTION
As discussed in yesterday's meeting, pushing timestamp in examples to match miliseconds instead of 1/100